### PR TITLE
Upgrade paramiko to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ansible==5.1.0
 colorama==0.4.1
-paramiko==2.10.1
+paramiko==2.11.0
 pytest==5.2.0
 pyvmomi==6.7.1.2018.12
 pywinrm==0.4.1


### PR DESCRIPTION
This simply upgrades `paramiko` to the latest version.
The main motivation for that is the removal of the `blowfish` cypher from the `cryptography` module, which generates a deprecation warning.

[Here](https://github.com/paramiko/paramiko/issues/2038) is the corresponding issue for that change.